### PR TITLE
Fix/convert to utc timezone correctly

### DIFF
--- a/examples/optimize.js
+++ b/examples/optimize.js
@@ -198,8 +198,8 @@ function convertToFSRSItem(history) {
 function dateDiffInDays(a, b) {
   const _MS_PER_DAY = 1000 * 60 * 60 * 24;
   // Discard the time and time-zone information.
-  const utc1 = Date.UTC(a.getUTCFullYear(), a.getUTCMonth() + 1, a.getUTCDate());
-  const utc2 = Date.UTC(b.getUTCFullYear(), b.getUTCMonth() + 1, b.getUTCDate());
+  const utc1 = Date.UTC(a.getUTCFullYear(), a.getUTCMonth(), a.getUTCDate());
+  const utc2 = Date.UTC(b.getUTCFullYear(), b.getUTCMonth(), b.getUTCDate());
 
   return Math.floor((utc2 - utc1) / _MS_PER_DAY)
 }

--- a/examples/optimize.js
+++ b/examples/optimize.js
@@ -188,11 +188,18 @@ function convertToFSRSItem(history) {
   return items.filter((item) => item.longTermReviewCnt() > 0)
 }
 
+/**
+ * Calculates the difference in days between two dates.
+ *
+ * @param {Date} a - The first date.
+ * @param {Date} b - The second date.
+ * @returns {number} The number of days between the two dates.
+ */
 function dateDiffInDays(a, b) {
   const _MS_PER_DAY = 1000 * 60 * 60 * 24;
   // Discard the time and time-zone information.
-  const utc1 = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());
-  const utc2 = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate());
+  const utc1 = Date.UTC(a.getUTCFullYear(), a.getUTCMonth() + 1, a.getUTCDate());
+  const utc2 = Date.UTC(b.getUTCFullYear(), b.getUTCMonth() + 1, b.getUTCDate());
 
   return Math.floor((utc2 - utc1) / _MS_PER_DAY)
 }


### PR DESCRIPTION
We should use `getUTCxxx()`, and note that `getUTCMonth` returns values in the range `[0, 11]`.
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth


![image](https://github.com/user-attachments/assets/dc6ba8d4-b269-4573-a061-f32539ad99f1)

![image](https://github.com/user-attachments/assets/4de2b50b-534b-45eb-b71e-85d0f542d24a)
