### PR TITLE
Fix/incorrect usage of the `skipEmptyLines` option

### DIFF
--- a/examples/train_csv.js
+++ b/examples/train_csv.js
@@ -19,7 +19,8 @@ async function main() {
     const results = []
     parseString(content, {
       headers: true,
-      skipEmptyLines: true,
+      ignoreEmpty: true,
+      trim: true,
     })
       .on('data', (row) => results.push(row))
       .on('error', (error) => reject(error))


### PR DESCRIPTION
ref: 

- https://c2fo.github.io/fast-csv/docs/parsing/options#ignoreempty
- https://github.com/C2FO/fast-csv/blob/6cf7f8fc052ad3c6906c7b4714c1c8d902c8632e/packages/parse/src/ParserOptions.ts#L5-L23